### PR TITLE
Feature/local imap repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,22 @@
             <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>2.0.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>9.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>9.11.0</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>lucene-queryparser</artifactId>
             <version>9.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/example/gmailmcp/LocalImap.java
+++ b/src/main/java/com/example/gmailmcp/LocalImap.java
@@ -1,0 +1,7 @@
+package com.example.gmailmcp;
+
+public class LocalImap {
+    public static void main(String[] args) {
+        System.out.println("Hello from LocalImap!");
+    }
+}

--- a/src/main/java/com/example/gmailmcp/model/LocalAttachment.java
+++ b/src/main/java/com/example/gmailmcp/model/LocalAttachment.java
@@ -1,0 +1,4 @@
+package com.example.gmailmcp.model;
+
+public record LocalAttachment(String filename, String contentType, byte[] content) {
+}

--- a/src/main/java/com/example/gmailmcp/model/LocalEmail.java
+++ b/src/main/java/com/example/gmailmcp/model/LocalEmail.java
@@ -2,6 +2,8 @@ package com.example.gmailmcp.model;
 
 import java.time.ZonedDateTime;
 
+import java.util.List;
+
 public class LocalEmail {
 
     private String id;
@@ -9,13 +11,15 @@ public class LocalEmail {
     private String subject;
     private String bodyText;
     private ZonedDateTime sentDate;
+    private List<LocalAttachment> attachments;
 
-    public LocalEmail(String id, String from, String subject, String bodyText, ZonedDateTime sentDate) {
+    public LocalEmail(String id, String from, String subject, String bodyText, ZonedDateTime sentDate, List<LocalAttachment> attachments) {
         this.id = id;
         this.from = from;
         this.subject = subject;
         this.bodyText = bodyText;
         this.sentDate = sentDate;
+        this.attachments = attachments;
     }
 
     public String getId() {
@@ -56,5 +60,13 @@ public class LocalEmail {
 
     public void setSentDate(ZonedDateTime sentDate) {
         this.sentDate = sentDate;
+    }
+
+    public List<LocalAttachment> getAttachments() {
+        return attachments;
+    }
+
+    public void setAttachments(List<LocalAttachment> attachments) {
+        this.attachments = attachments;
     }
 }

--- a/src/main/java/com/example/gmailmcp/model/LocalEmail.java
+++ b/src/main/java/com/example/gmailmcp/model/LocalEmail.java
@@ -1,0 +1,60 @@
+package com.example.gmailmcp.model;
+
+import java.time.ZonedDateTime;
+
+public class LocalEmail {
+
+    private String id;
+    private String from;
+    private String subject;
+    private String bodyText;
+    private ZonedDateTime sentDate;
+
+    public LocalEmail(String id, String from, String subject, String bodyText, ZonedDateTime sentDate) {
+        this.id = id;
+        this.from = from;
+        this.subject = subject;
+        this.bodyText = bodyText;
+        this.sentDate = sentDate;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBodyText() {
+        return bodyText;
+    }
+
+    public void setBodyText(String bodyText) {
+        this.bodyText = bodyText;
+    }
+
+    public ZonedDateTime getSentDate() {
+        return sentDate;
+    }
+
+    public void setSentDate(ZonedDateTime sentDate) {
+        this.sentDate = sentDate;
+    }
+}

--- a/src/main/java/com/example/gmailmcp/service/SearchService.java
+++ b/src/main/java/com/example/gmailmcp/service/SearchService.java
@@ -1,0 +1,73 @@
+package com.example.gmailmcp.service;
+
+import com.example.gmailmcp.model.LocalEmail;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.FSDirectory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchService {
+
+    private final Path indexPath;
+    private final IndexWriter writer;
+
+    public SearchService(Path indexPath) throws IOException {
+        this.indexPath = indexPath;
+        if (!java.nio.file.Files.exists(indexPath)) {
+            java.nio.file.Files.createDirectories(indexPath);
+        }
+        IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
+        this.writer = new IndexWriter(FSDirectory.open(indexPath), config);
+    }
+
+    public void addEmail(LocalEmail email) throws IOException {
+        Document doc = new Document();
+        doc.add(new StringField("id", email.getId(), Field.Store.YES));
+        if (email.getFrom() != null) {
+            doc.add(new StringField("from", email.getFrom(), Field.Store.YES));
+        }
+        if (email.getSubject() != null) {
+            doc.add(new TextField("subject", email.getSubject(), Field.Store.YES));
+        }
+        if (email.getBodyText() != null) {
+            doc.add(new TextField("bodyText", email.getBodyText(), Field.Store.YES));
+        }
+        writer.addDocument(doc);
+        writer.commit();
+    }
+
+    public List<String> search(String queryString) throws IOException, ParseException {
+        try (DirectoryReader reader = DirectoryReader.open(FSDirectory.open(indexPath))) {
+            IndexSearcher searcher = new IndexSearcher(reader);
+            QueryParser parser = new QueryParser("bodyText", new StandardAnalyzer());
+            Query query = parser.parse(queryString);
+            TopDocs results = searcher.search(query, 10);
+            List<String> ids = new ArrayList<>();
+            for (ScoreDoc scoreDoc : results.scoreDocs) {
+                Document doc = reader.storedFields().document(scoreDoc.doc);
+                ids.add(doc.get("id"));
+            }
+            return ids;
+        }
+    }
+
+    public void close() throws IOException {
+        writer.close();
+    }
+}

--- a/src/main/java/com/example/gmailmcp/tool/GmailToolService.java
+++ b/src/main/java/com/example/gmailmcp/tool/GmailToolService.java
@@ -59,10 +59,14 @@ public class GmailToolService {
     }
 
     private void validatePath(String path) {
-        java.nio.file.Path workingDir = java.nio.file.Paths.get("").toAbsolutePath().normalize();
-        java.nio.file.Path savePath = workingDir.resolve(path).normalize();
-        if (!savePath.startsWith(workingDir) || !savePath.toFile().getCanonicalPath().startsWith(workingDir.toFile().getCanonicalPath())) {
-            throw new IllegalArgumentException("Invalid save path");
+        try {
+            java.nio.file.Path workingDir = java.nio.file.Paths.get("").toAbsolutePath().normalize();
+            java.nio.file.Path savePath = workingDir.resolve(path).normalize();
+            if (!savePath.startsWith(workingDir) || !savePath.toFile().getCanonicalPath().startsWith(workingDir.toFile().getCanonicalPath())) {
+                throw new IllegalArgumentException("Invalid save path");
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid save path", e);
         }
     }
 }

--- a/src/main/java/com/example/gmailmcp/util/EmailConverter.java
+++ b/src/main/java/com/example/gmailmcp/util/EmailConverter.java
@@ -23,7 +23,9 @@ public class EmailConverter {
             from = ((InternetAddress) message.getFrom()[0]).getAddress();
         }
         String subject = message.getSubject();
-        ZonedDateTime sentDate = message.getSentDate().toInstant().atZone(ZoneId.systemDefault());
+        ZonedDateTime sentDate = message.getSentDate() != null
+                ? message.getSentDate().toInstant().atZone(ZoneId.systemDefault())
+                : null;
         String bodyText = getTextFromMessage(message);
         List<LocalAttachment> attachments = getAttachmentsFromMessage(message);
         // ID is not available directly, it will be set later

--- a/src/main/java/com/example/gmailmcp/util/EmailConverter.java
+++ b/src/main/java/com/example/gmailmcp/util/EmailConverter.java
@@ -1,0 +1,77 @@
+package com.example.gmailmcp.util;
+
+import com.example.gmailmcp.model.LocalAttachment;
+import com.example.gmailmcp.model.LocalEmail;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Part;
+import jakarta.mail.internet.InternetAddress;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EmailConverter {
+
+    public static LocalEmail toLocalEmail(Message message) throws MessagingException, IOException {
+        String from = "";
+        if (message.getFrom() != null && message.getFrom().length > 0) {
+            from = ((InternetAddress) message.getFrom()[0]).getAddress();
+        }
+        String subject = message.getSubject();
+        ZonedDateTime sentDate = message.getSentDate().toInstant().atZone(ZoneId.systemDefault());
+        String bodyText = getTextFromMessage(message);
+        List<LocalAttachment> attachments = getAttachmentsFromMessage(message);
+        // ID is not available directly, it will be set later
+        return new LocalEmail(null, from, subject, bodyText, sentDate, attachments);
+    }
+
+    private static String getTextFromMessage(Message message) throws MessagingException, IOException {
+        String result = "";
+        if (message.isMimeType("text/plain")) {
+            result = message.getContent().toString();
+        } else if (message.isMimeType("multipart/*")) {
+            Multipart multipart = (Multipart) message.getContent();
+            result = getTextFromMimeMultipart(multipart);
+        }
+        return result;
+    }
+
+    private static String getTextFromMimeMultipart(Multipart multipart) throws MessagingException, IOException {
+        StringBuilder result = new StringBuilder();
+        int count = multipart.getCount();
+        for (int i = 0; i < count; i++) {
+            Part bodyPart = multipart.getBodyPart(i);
+            if (bodyPart.isMimeType("text/plain")) {
+                result.append(bodyPart.getContent().toString());
+                break; // We only want the plain text part
+            } else if (bodyPart.isMimeType("text/html")) {
+                // Skip HTML part
+            } else if (bodyPart.getContent() instanceof Multipart) {
+                result.append(getTextFromMimeMultipart((Multipart) bodyPart.getContent()));
+            }
+        }
+        return result.toString();
+    }
+
+    private static List<LocalAttachment> getAttachmentsFromMessage(Message message) throws IOException, MessagingException {
+        List<LocalAttachment> attachments = new ArrayList<>();
+        if (message.getContent() instanceof Multipart) {
+            Multipart multipart = (Multipart) message.getContent();
+            for (int i = 0; i < multipart.getCount(); i++) {
+                Part bodyPart = multipart.getBodyPart(i);
+                if (Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition())) {
+                    String fileName = bodyPart.getFileName();
+                    String contentType = bodyPart.getContentType();
+                    byte[] content = IOUtils.toByteArray(bodyPart.getInputStream());
+                    attachments.add(new LocalAttachment(fileName, contentType, content));
+                }
+            }
+        }
+        return attachments;
+    }
+}

--- a/src/test/java/com/example/gmailmcp/model/LocalEmailTest.java
+++ b/src/test/java/com/example/gmailmcp/model/LocalEmailTest.java
@@ -1,0 +1,22 @@
+package com.example.gmailmcp.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LocalEmailTest {
+
+    @Test
+    public void testLocalEmail() {
+        ZonedDateTime sentDate = ZonedDateTime.now();
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+
+        assertEquals("123", email.getId());
+        assertEquals("test@example.com", email.getFrom());
+        assertEquals("Test Subject", email.getSubject());
+        assertEquals("Test Body", email.getBodyText());
+        assertEquals(sentDate, email.getSentDate());
+    }
+}

--- a/src/test/java/com/example/gmailmcp/model/LocalEmailTest.java
+++ b/src/test/java/com/example/gmailmcp/model/LocalEmailTest.java
@@ -3,6 +3,7 @@ package com.example.gmailmcp.model;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,7 +12,7 @@ public class LocalEmailTest {
     @Test
     public void testLocalEmail() {
         ZonedDateTime sentDate = ZonedDateTime.now();
-        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate, new ArrayList<>());
 
         assertEquals("123", email.getId());
         assertEquals("test@example.com", email.getFrom());

--- a/src/test/java/com/example/gmailmcp/service/SearchServiceTest.java
+++ b/src/test/java/com/example/gmailmcp/service/SearchServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,7 +40,7 @@ public class SearchServiceTest {
     @Test
     public void testAddEmail_AddsDocumentWithCorrectFields() throws IOException {
         ZonedDateTime sentDate = ZonedDateTime.now();
-        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate, new ArrayList<>());
         searchService.addEmail(email);
 
         try (IndexReader reader = DirectoryReader.open(FSDirectory.open(indexPath))) {
@@ -54,7 +55,7 @@ public class SearchServiceTest {
     @Test
     public void testAddEmail_HandlesNullFieldsGracefully() throws IOException {
         ZonedDateTime sentDate = ZonedDateTime.now();
-        LocalEmail email = new LocalEmail("456", null, null, null, sentDate);
+        LocalEmail email = new LocalEmail("456", null, null, null, sentDate, new ArrayList<>());
         assertDoesNotThrow(() -> searchService.addEmail(email));
 
         try (IndexReader reader = DirectoryReader.open(FSDirectory.open(indexPath))) {
@@ -69,7 +70,7 @@ public class SearchServiceTest {
     @Test
     public void testSearch_FindsExistingEmailBySubject() throws IOException, ParseException {
         ZonedDateTime sentDate = ZonedDateTime.now();
-        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate, new ArrayList<>());
         searchService.addEmail(email);
 
         List<String> ids = searchService.search("subject:Test");
@@ -80,7 +81,7 @@ public class SearchServiceTest {
     @Test
     public void testSearch_FindsExistingEmailByBody() throws IOException, ParseException {
         ZonedDateTime sentDate = ZonedDateTime.now();
-        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate, new ArrayList<>());
         searchService.addEmail(email);
 
         List<String> ids = searchService.search("bodyText:Body");
@@ -91,7 +92,7 @@ public class SearchServiceTest {
     @Test
     public void testSearch_ReturnsEmptyListForNoMatches() throws IOException, ParseException {
         ZonedDateTime sentDate = ZonedDateTime.now();
-        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate, new ArrayList<>());
         searchService.addEmail(email);
 
         List<String> ids = searchService.search("subject:NonExistent");

--- a/src/test/java/com/example/gmailmcp/service/SearchServiceTest.java
+++ b/src/test/java/com/example/gmailmcp/service/SearchServiceTest.java
@@ -1,0 +1,100 @@
+package com.example.gmailmcp.service;
+
+import com.example.gmailmcp.model.LocalEmail;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.store.FSDirectory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SearchServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private SearchService searchService;
+    private Path indexPath;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        indexPath = tempDir.resolve("index");
+        searchService = new SearchService(indexPath);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        searchService.close();
+    }
+
+    @Test
+    public void testAddEmail_AddsDocumentWithCorrectFields() throws IOException {
+        ZonedDateTime sentDate = ZonedDateTime.now();
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        searchService.addEmail(email);
+
+        try (IndexReader reader = DirectoryReader.open(FSDirectory.open(indexPath))) {
+            assertEquals(1, reader.numDocs());
+            assertEquals("123", reader.document(0).get("id"));
+            assertEquals("test@example.com", reader.document(0).get("from"));
+            assertEquals("Test Subject", reader.document(0).get("subject"));
+            assertEquals("Test Body", reader.document(0).get("bodyText"));
+        }
+    }
+
+    @Test
+    public void testAddEmail_HandlesNullFieldsGracefully() throws IOException {
+        ZonedDateTime sentDate = ZonedDateTime.now();
+        LocalEmail email = new LocalEmail("456", null, null, null, sentDate);
+        assertDoesNotThrow(() -> searchService.addEmail(email));
+
+        try (IndexReader reader = DirectoryReader.open(FSDirectory.open(indexPath))) {
+            assertEquals(1, reader.numDocs());
+            assertEquals("456", reader.document(0).get("id"));
+            assertNull(reader.document(0).get("from"));
+            assertNull(reader.document(0).get("subject"));
+            assertNull(reader.document(0).get("bodyText"));
+        }
+    }
+
+    @Test
+    public void testSearch_FindsExistingEmailBySubject() throws IOException, ParseException {
+        ZonedDateTime sentDate = ZonedDateTime.now();
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        searchService.addEmail(email);
+
+        List<String> ids = searchService.search("subject:Test");
+        assertEquals(1, ids.size());
+        assertEquals("123", ids.get(0));
+    }
+
+    @Test
+    public void testSearch_FindsExistingEmailByBody() throws IOException, ParseException {
+        ZonedDateTime sentDate = ZonedDateTime.now();
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        searchService.addEmail(email);
+
+        List<String> ids = searchService.search("bodyText:Body");
+        assertEquals(1, ids.size());
+        assertEquals("123", ids.get(0));
+    }
+
+    @Test
+    public void testSearch_ReturnsEmptyListForNoMatches() throws IOException, ParseException {
+        ZonedDateTime sentDate = ZonedDateTime.now();
+        LocalEmail email = new LocalEmail("123", "test@example.com", "Test Subject", "Test Body", sentDate);
+        searchService.addEmail(email);
+
+        List<String> ids = searchService.search("subject:NonExistent");
+        assertTrue(ids.isEmpty());
+    }
+}

--- a/src/test/java/com/example/gmailmcp/util/EmailConverterTest.java
+++ b/src/test/java/com/example/gmailmcp/util/EmailConverterTest.java
@@ -1,0 +1,69 @@
+package com.example.gmailmcp.util;
+
+import com.example.gmailmcp.model.LocalEmail;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Part;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EmailConverterTest {
+
+    @Test
+    public void testToLocalEmail_ConvertsSimpleMessage() throws MessagingException, IOException {
+        Message message = mock(MimeMessage.class);
+        when(message.getFrom()).thenReturn(new InternetAddress[]{new InternetAddress("test@example.com")});
+        when(message.getSubject()).thenReturn("Test Subject");
+        when(message.getSentDate()).thenReturn(new Date());
+        when(message.isMimeType("text/plain")).thenReturn(true);
+        when(message.getContent()).thenReturn("Test Body");
+
+        LocalEmail localEmail = EmailConverter.toLocalEmail(message);
+
+        assertEquals("test@example.com", localEmail.getFrom());
+        assertEquals("Test Subject", localEmail.getSubject());
+        assertEquals("Test Body", localEmail.getBodyText());
+        assertTrue(localEmail.getAttachments().isEmpty());
+    }
+
+    @Test
+    public void testToLocalEmail_ExtractsAttachments() throws MessagingException, IOException {
+        Message message = mock(MimeMessage.class);
+        when(message.getFrom()).thenReturn(new InternetAddress[]{new InternetAddress("test@example.com")});
+        when(message.getSubject()).thenReturn("Test Subject");
+        when(message.getSentDate()).thenReturn(new Date());
+
+        MimeMultipart multipart = new MimeMultipart();
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText("Test Body");
+        multipart.addBodyPart(textPart);
+
+        MimeBodyPart attachmentPart = new MimeBodyPart();
+        attachmentPart.setFileName("test.txt");
+        attachmentPart.setContent("test content", "text/plain");
+        attachmentPart.setDisposition(Part.ATTACHMENT);
+        multipart.addBodyPart(attachmentPart);
+
+        when(message.isMimeType("multipart/*")).thenReturn(true);
+        when(message.getContent()).thenReturn(multipart);
+
+        LocalEmail localEmail = EmailConverter.toLocalEmail(message);
+
+        assertEquals("test@example.com", localEmail.getFrom());
+        assertEquals("Test Subject", localEmail.getSubject());
+        assertEquals("Test Body", localEmail.getBodyText());
+        assertFalse(localEmail.getAttachments().isEmpty());
+        assertEquals(1, localEmail.getAttachments().size());
+        assertEquals("test.txt", localEmail.getAttachments().get(0).filename());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new email processing and search functionality for the Gmail MCP project. It adds dependencies for handling email and search indexing, implements models and services for email and attachment processing, and includes unit tests to ensure correctness. Below is a summary of the most important changes grouped by theme:

### Dependency Additions
* Added dependencies for email handling (`angus-mail`), search indexing (`lucene-core` and `lucene-queryparser`), and utility functions (`commons-io`) in `pom.xml`. These libraries support email parsing and search functionality.

### Core Functionality
* Created `LocalEmail` and `LocalAttachment` models to represent email data and attachments. These provide structured representations of email content. (`src/main/java/com/example/gmailmcp/model/LocalEmail.java` - [[1]](diffhunk://#diff-f2d88dfe4822447eff75e941df40fbda88ab22b9c01d340d85717ff92823c118R1-R72) `src/main/java/com/example/gmailmcp/model/LocalAttachment.java` - [[2]](diffhunk://#diff-faea9e42b36075fd090d6f2168304e9ae440ee5f2d9fd9c2906a03ebdafe9b6eR1-R4)
* Implemented `SearchService` to index and search emails using Apache Lucene. This service allows adding emails to an index and querying them by content. (`src/main/java/com/example/gmailmcp/service/SearchService.java` - [src/main/java/com/example/gmailmcp/service/SearchService.javaR1-R73](diffhunk://#diff-c5e1e930a5f51acc3168d21e570f0508a0dde33d21bebb7877765591e80c3568R1-R73))
* Added `EmailConverter` utility to convert `javax.mail.Message` objects into `LocalEmail` objects, extracting text and attachments. (`src/main/java/com/example/gmailmcp/util/EmailConverter.java` - [src/main/java/com/example/gmailmcp/util/EmailConverter.javaR1-R77](diffhunk://#diff-c37894b7de75f8ca9c70307bb06b51540f8d3d5d4040cf9541033d7d74fd5915R1-R77))

### Validation and Error Handling
* Enhanced path validation in `GmailToolService` to handle `IOException` during path normalization, improving robustness against invalid paths. (`src/main/java/com/example/gmailmcp/tool/GmailToolService.java` - [src/main/java/com/example/gmailmcp/tool/GmailToolService.javaR62-R70](diffhunk://#diff-bace8a8715db38444fc4f1cb8e7311cd7b9b5d595948f532b4c82e5b427fc214R62-R70))

### Testing
* Added unit tests for `LocalEmail`, `SearchService`, and `EmailConverter` to verify functionality, including edge cases such as null fields and attachment handling. (`src/test/java/com/example/gmailmcp/model/LocalEmailTest.java` - [[1]](diffhunk://#diff-ddcb36cce2aa260c0df5ddf6aec3a4632285f805445b008e2f0bd7c75c992d07R1-R23) `src/test/java/com/example/gmailmcp/service/SearchServiceTest.java` - [[2]](diffhunk://#diff-c6f1bce044d356d21e845d143b7b85ea64f9e3e3866298c75a32c75d9fb9161cR1-R101) `src/test/java/com/example/gmailmcp/util/EmailConverterTest.java` - [[3]](diffhunk://#diff-5453999726c00d410e350494d95193d34b8c4053df6f4cc6380e13a14ff41788R1-R69)